### PR TITLE
Align env helpers with latest API

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -144,7 +144,7 @@ Error: Missing required environment variables: SUPABASE_SERVICE_ROLE_KEY
 Check environment status programmatically:
 
 ```typescript
-import { getEnvironmentStatus } from '@/lib/env'
+import { getEnvironmentStatus } from '@/lib/validateEnv'
 
 const status = getEnvironmentStatus()
 console.log(status)
@@ -155,9 +155,9 @@ console.log(status)
 The application provides detailed validation errors:
 
 ```typescript
-import { validateEnvironmentSync } from '@/lib/env'
+import { validateSupabaseEnv } from '@/lib/validateEnv'
 
-const validation = validateEnvironmentSync()
+const validation = await validateSupabaseEnv()
 if (!validation.isValid) {
   console.error('Environment errors:', validation.errors)
 }

--- a/src/tests/lib/env.test.ts
+++ b/src/tests/lib/env.test.ts
@@ -1,144 +1,94 @@
 /* eslint-disable no-process-env */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { 
-  validateEnvironmentSync, 
-  getEnvironmentStatus, 
-  checkCriticalEnvVars,
-  EnvironmentConfigError
-} from '@/lib/env'
+import {
+  validateSupabaseEnv,
+  getEnvironmentStatus,
+  validateEnvironmentSync
+} from '@/lib/validateEnv'
 
-// Store original environment
 const originalEnv = process.env
 
 describe('Environment Validation', () => {
   beforeEach(() => {
-    // Reset process.env before each test
     process.env = { ...originalEnv }
   })
 
   afterEach(() => {
-    // Restore original environment
     process.env = originalEnv
   })
 
-  describe('validateEnvironmentSync', () => {
-    it('should validate successfully with all required variables', () => {
+  describe('validateSupabaseEnv', () => {
+    it('validates successfully with all required variables', async () => {
       process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co'
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key'
       process.env.OPENAI_API_KEY = 'sk-test-key'
       process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-key'
 
-      const result = validateEnvironmentSync()
+      const result = await validateSupabaseEnv()
       expect(result.isValid).toBe(true)
       expect(result.errors).toHaveLength(0)
     })
 
-    it('should fail validation with missing client variables', () => {
+    it('fails validation with missing client variables', async () => {
       delete process.env.NEXT_PUBLIC_SUPABASE_URL
       delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
-      const result = validateEnvironmentSync()
+      const result = await validateSupabaseEnv()
       expect(result.isValid).toBe(false)
-      expect(result.errors.length).toBeGreaterThan(0)
       expect(result.missingVars).toContain('NEXT_PUBLIC_SUPABASE_URL')
       expect(result.missingVars).toContain('NEXT_PUBLIC_SUPABASE_ANON_KEY')
     })
 
-    it('should fail validation with invalid Supabase URL', () => {
+    it('fails validation with invalid Supabase URL', async () => {
       process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://invalid-url.com'
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-key'
 
-      const result = validateEnvironmentSync()
+      const result = await validateSupabaseEnv()
       expect(result.isValid).toBe(false)
       expect(result.errors.some(error => error.includes('Supabase URL'))).toBe(true)
     })
 
-    it('should include warnings for optional variables', () => {
+    it('includes warnings for optional variables', async () => {
       process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co'
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-key'
       delete process.env.NEXT_PUBLIC_POSTHOG_KEY
 
+      const result = await validateSupabaseEnv()
+      expect(result.warnings.some(w => w.includes('PostHog'))).toBe(true)
+    })
+  })
+
+  describe('validateEnvironmentSync', () => {
+    it('reports missing vars synchronously', () => {
+      delete process.env.NEXT_PUBLIC_SUPABASE_URL
       const result = validateEnvironmentSync()
-      expect(result.warnings.some(warning => warning.includes('PostHog'))).toBe(true)
+      expect(result.isValid).toBe(false)
+      expect(result.missingVars).toContain('NEXT_PUBLIC_SUPABASE_URL')
     })
   })
 
   describe('getEnvironmentStatus', () => {
-    it('should return safe environment status', () => {
+    it('returns safe environment status', () => {
       process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://very-long-supabase-url-that-should-be-truncated.supabase.co'
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-key'
       process.env.OPENAI_API_KEY = 'sk-test-key'
 
       const status = getEnvironmentStatus()
-      
+
       expect(status.supabaseUrl).toContain('...')
-      expect(status.supabaseUrl.length).toBeLessThanOrEqual(33) // 30 chars + '...'
-      expect(status.hasSupabaseAnonKey).toBe(true)
+      expect(status.supabaseUrl.length).toBeLessThanOrEqual(33)
+      expect(status.hasAnonKey).toBe(true)
       expect(status.hasOpenAIKey).toBe(true)
-      expect(status.environment).toBeDefined()
     })
 
-    it('should handle missing environment variables safely', () => {
+    it('handles missing environment variables safely', () => {
       delete process.env.NEXT_PUBLIC_SUPABASE_URL
       delete process.env.OPENAI_API_KEY
 
       const status = getEnvironmentStatus()
       expect(status.supabaseUrl).toBe('NOT_SET')
-      expect(status.hasSupabaseAnonKey).toBe(false)
+      expect(status.hasAnonKey).toBe(false)
       expect(status.hasOpenAIKey).toBe(false)
     })
   })
-
-  describe('checkCriticalEnvVars', () => {
-    it('should pass with critical variables present', () => {
-      process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co'
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-key'
-
-      expect(() => checkCriticalEnvVars()).not.toThrow()
-    })
-
-    it('should throw EnvironmentConfigError with missing critical variables', () => {
-      delete process.env.NEXT_PUBLIC_SUPABASE_URL
-      delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-
-      expect(() => checkCriticalEnvVars()).toThrow(EnvironmentConfigError)
-      
-      try {
-        checkCriticalEnvVars()
-      } catch (error) {
-        expect(error).toBeInstanceOf(EnvironmentConfigError)
-        expect((error as EnvironmentConfigError).missingVars).toContain('NEXT_PUBLIC_SUPABASE_URL')
-        expect((error as EnvironmentConfigError).missingVars).toContain('NEXT_PUBLIC_SUPABASE_ANON_KEY')
-      }
-    })
-
-    it('should throw with descriptive error message', () => {
-      delete process.env.NEXT_PUBLIC_SUPABASE_URL
-
-      expect(() => checkCriticalEnvVars()).toThrow(/Critical environment variables are missing/)
-    })
-  })
-
-  describe('EnvironmentConfigError', () => {
-    it('should create error with missing variables and validation errors', () => {
-      const missingVars = ['VAR1', 'VAR2']
-      const validationErrors = ['Error 1', 'Error 2']
-      
-      const error = new EnvironmentConfigError('Test error', missingVars, validationErrors)
-      
-      expect(error.name).toBe('EnvironmentConfigError')
-      expect(error.message).toBe('Test error')
-      expect(error.missingVars).toEqual(missingVars)
-      expect(error.validationErrors).toEqual(validationErrors)
-    })
-
-    it('should work with minimal parameters', () => {
-      const error = new EnvironmentConfigError('Simple error')
-      
-      expect(error.name).toBe('EnvironmentConfigError')
-      expect(error.message).toBe('Simple error')
-      expect(error.missingVars).toEqual([])
-      expect(error.validationErrors).toEqual([])
-    })
-  })
-}) 
+})


### PR DESCRIPTION
## Summary
- update documentation for new env helper locations
- rewrite environment unit tests to import from `validateEnv`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877442ec000832a9695cf43987f96da

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated environment setup documentation to reflect new import paths and usage examples for environment validation.

* **Tests**
  * Refactored environment validation tests to use updated import paths and asynchronous validation functions.
  * Updated test assertions and descriptions to match the latest environment validation logic.
  * Removed obsolete tests related to deprecated validation methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->